### PR TITLE
Align text on association cards

### DIFF
--- a/frontend/src/components/pages/federation/AssociationCard.vue
+++ b/frontend/src/components/pages/federation/AssociationCard.vue
@@ -100,7 +100,7 @@
             >
                 <FontAwesomeIcon
                     class="network"
-                    :icon="['fas','discord']"
+                    :icon="['fab','discord']"
                 />
             </a>
         </div>

--- a/frontend/src/components/pages/federation/AssociationCard.vue
+++ b/frontend/src/components/pages/federation/AssociationCard.vue
@@ -183,18 +183,25 @@ export default defineComponent({
         }
     }
 
-    h2 {
-        font-size: 1.5rem;
-        font-weight: 600;
-        margin: 0;
-        padding: 0;
+    .title {
+        flex-grow: 1;
+        display: flex;
+        align-items: center;
 
-        background: var(--gradient);
-        display: inline-block;
-        color: transparent;
-        -webkit-background-clip: text;
-        text-shadow: 0 0 16px var(--color-primary-lite);
+        h2 {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin: 0;
+            padding: 0;
+
+            background: var(--gradient);
+            display: inline-block;
+            color: transparent;
+            -webkit-background-clip: text;
+            text-shadow: 0 0 16px var(--color-primary-lite);
+        }
     }
+    
 
     .region {
         text-transform: uppercase;

--- a/frontend/src/components/pages/federation/AssociationCard.vue
+++ b/frontend/src/components/pages/federation/AssociationCard.vue
@@ -185,8 +185,6 @@ export default defineComponent({
 
     .title {
         flex-grow: 1;
-        display: flex;
-        align-items: center;
 
         h2 {
             font-size: 1.5rem;


### PR DESCRIPTION
Alignement du texte des cards de la page fédération. 
J'ai ajouté un `align-items` pour avoir le titre centré verticalement, ce qui donne cela :

![image](https://user-images.githubusercontent.com/23261995/226581406-41125648-0bde-4995-b2c3-ee8a37d03316.png)

à la place de 

![image](https://user-images.githubusercontent.com/23261995/226581484-b6373b17-ba41-4376-990d-c090087954a9.png)
